### PR TITLE
OM-369: adjustments to add new way of authorizing users

### DIFF
--- a/msystems/apps.py
+++ b/msystems/apps.py
@@ -15,6 +15,7 @@ DEFAULT_CFG = {
         "mpass_key_dob": "BirthDate",
         "mpass_key_roles": "Role",
         "mpass_key_legal_entities": "OrganizationAdministrator",
+        "mpass_key_additional_legal_entity": "AdministeredEntities",
         # "mpass_key_legal_entities": "AdministeredLegalEntity",
 
 

--- a/msystems/services/mpass_user_service.py
+++ b/msystems/services/mpass_user_service.py
@@ -78,6 +78,9 @@ class MpassUserService:
             self._update_user_name(user.i_user, data_first_name, data_last_name)
 
     def _update_user_legal_entities(self, user: User, user_data: dict) -> None:
+        if MsystemsConfig.mpass_config["mpass_key_additional_legal_entity"] in user_data:
+            user_data[MsystemsConfig.mpass_config["mpass_key_legal_entities"]] \
+                = user_data[MsystemsConfig.mpass_config["mpass_key_additional_legal_entity"]]
         legal_entities = self._parse_legal_entities(user_data.get(MsystemsConfig.mpass_config["mpass_key_legal_entities"], []))
         policyholders = [self._get_or_create_policy_holder(user, line[1], line[0]) for line in legal_entities]
 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OM-369

PR introduces new way of authorizing via for example electronic signature (powered by MPower). New attribute is conveyed by MPass and openIMIS backend processes it like in authorization via username/password.